### PR TITLE
Fix firmware version check to exclude only 2.3.1 spam

### DIFF
--- a/cmd/meshobserv/meshobserv.go
+++ b/cmd/meshobserv/meshobserv.go
@@ -132,7 +132,7 @@ func handleMessage(from uint32, topic string, portNum generated.PortNum, payload
 		}
 		fwVersion := mapReport.GetFirmwareVersion()
 		// 2.3.1 has a bug that spams multiple MapReports every second
-		if len(fwVersion) > 5 && fwVersion[:5] == "2.3.1" {
+		if len(fwVersion) > 5 && fwVersion[:5] == "2.3.1" || strings.HasPrefix(fwVersion, "2.3.1.") {
 			return
 		}
 		longName := mapReport.GetLongName()


### PR DESCRIPTION
This change prevents newer versions like 2.3.10 and 2.3.11 from being incorrectly filtered out. This addresses the issues reported in GitHub issue #12