### PR TITLE
Add maximum resolution note to location accuracy notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ If your node can be heard by another node already reporting to MQTT, that's it!
 #### Important update as of August, 2024
 Meshtastic has [made a change to their MQTT server](https://meshtastic.org/blog/recent-public-mqtt-broker-changes/):
 
-> Only position packets with imprecise location information [10-16 bits] will be passed to the topic, ensuring that sensitive data is not exposed. (364 Meters/1194 Feet is the most accurate resolution allowed.)
+Only position packets with imprecise location information [10-16 bits] will be passed to the topic, ensuring that sensitive data is not exposed.
+
+The most accurate resolution that conforms to this specification is: 364 meters/1194 feet.
 
 Additionally, only the default [LoRa region](https://meshtastic.org/docs/configuration/radio/lora/#region)-based root topics (and all subtopics) are now monitored.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If your node can be heard by another node already reporting to MQTT, that's it!
 #### Important update as of August, 2024
 Meshtastic has [made a change to their MQTT server](https://meshtastic.org/blog/recent-public-mqtt-broker-changes/):
 
-> Only position packets with imprecise location information [10-16 bits] will be passed to the topic, ensuring that sensitive data is not exposed.
+> Only position packets with imprecise location information [10-16 bits] will be passed to the topic, ensuring that sensitive data is not exposed. (364 Meters/1194 Feet is the most accurate resolution allowed.)
 
 Additionally, only the default [LoRa region](https://meshtastic.org/docs/configuration/radio/lora/#region)-based root topics (and all subtopics) are now monitored.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If your node can be heard by another node already reporting to MQTT, that's it!
 #### Important update as of August, 2024
 Meshtastic has [made a change to their MQTT server](https://meshtastic.org/blog/recent-public-mqtt-broker-changes/):
 
-Only position packets with imprecise location information [10-16 bits] will be passed to the topic, ensuring that sensitive data is not exposed.
+> Only position packets with imprecise location information [10-16 bits] will be passed to the topic, ensuring that sensitive data is not exposed.
 
 The most accurate resolution that conforms to this specification is: 364 meters/1194 feet.
 


### PR DESCRIPTION
I had to look up what the setting was allowed to be, so I figured I'd relay that information where it may be useful.