### PR TITLE
simplified docker setup - configurable mqtt-broker

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,7 @@
+# MQTT broker connection
+MQTT_BROKER=tcp://mqtt.meshtastic.org:1883
+MQTT_USERNAME=meshdev
+MQTT_PASSWORD=large4cats
+
+# HTTP port exposed by nginx
+HTTP_PORT=10081

--- a/.env.sample
+++ b/.env.sample
@@ -5,3 +5,7 @@ MQTT_PASSWORD=large4cats
 
 # HTTP port exposed by nginx
 HTTP_PORT=10081
+
+# Site branding shown in the header
+SITE_TITLE=MeshMap
+SITE_URL=https://meshmap.net/

--- a/Dockerfile.meshobserv
+++ b/Dockerfile.meshobserv
@@ -4,7 +4,7 @@ COPY go.mod ./
 COPY cmd/meshobserv ./
 COPY internal ./internal/
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends protobuf-compiler git && \
+    apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev git && \
     rm -rf /var/lib/apt/lists/*
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 RUN git clone --depth 1 https://github.com/meshtastic/protobufs.git /tmp/protobufs && \

--- a/Dockerfile.meshobserv
+++ b/Dockerfile.meshobserv
@@ -3,6 +3,17 @@ WORKDIR /build
 COPY go.mod ./
 COPY cmd/meshobserv ./
 COPY internal ./internal/
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends protobuf-compiler git && \
+    rm -rf /var/lib/apt/lists/*
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+RUN git clone --depth 1 https://github.com/meshtastic/protobufs.git /tmp/protobufs && \
+    protoc \
+        -I=/tmp/protobufs \
+        --go_out=/build/internal/meshtastic \
+        --go_opt=module=github.com/meshtastic/go \
+        /tmp/protobufs/nanopb.proto \
+        /tmp/protobufs/meshtastic/*.proto
 RUN go mod tidy
 RUN go build -v -o meshobserv
 

--- a/Dockerfile.meshobserv
+++ b/Dockerfile.meshobserv
@@ -10,6 +10,7 @@ RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 RUN git clone --depth 1 https://github.com/meshtastic/protobufs.git /tmp/protobufs && \
     protoc \
         -I=/tmp/protobufs \
+        -I=/usr/include \
         --go_out=/build/internal/meshtastic \
         --go_opt=module=github.com/meshtastic/go \
         /tmp/protobufs/nanopb.proto \

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,0 +1,5 @@
+FROM nginx:alpine
+COPY website/ /website-static/
+COPY configs/nginx-http.conf /etc/nginx/conf.d/default.conf
+COPY scripts/init-website.sh /docker-entrypoint.d/50-init-website.sh
+RUN chmod +x /docker-entrypoint.d/50-init-website.sh

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,5 +1,3 @@
 FROM nginx:alpine
-COPY website/ /website-static/
-COPY configs/nginx-http.conf /etc/nginx/conf.d/default.conf
-COPY scripts/init-website.sh /docker-entrypoint.d/50-init-website.sh
-RUN chmod +x /docker-entrypoint.d/50-init-website.sh
+COPY scripts/init-nginx.sh /docker-entrypoint.d/10-init-site.sh
+RUN chmod +x /docker-entrypoint.d/10-init-site.sh

--- a/configs/nginx-http.conf
+++ b/configs/nginx-http.conf
@@ -1,7 +1,7 @@
 server {
     listen 80;
     listen [::]:80;
-    server_name meshmap.net;
+    server_name _;
     root /data/meshmap.net/website;
     location / {
         index index.html;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,11 @@ services:
       dockerfile: Dockerfile.meshobserv
     volumes:
       - ./website:/data/meshmap.net/website
-      - ./configs/blocklist.txt:/data/meshmap.net/blocklist.txt:ro
-    command:
-      - "-f"
-      - "/data/meshmap.net/website/nodes.json"
-      - "-b"
-      - "/data/meshmap.net/blocklist.txt"
+      - ./configs:/data/meshmap.net/configs
+    entrypoint:
+      - "/bin/sh"
+      - "-c"
+      - "touch /data/meshmap.net/configs/blocklist.txt && exec /usr/bin/meshobserv -f /data/meshmap.net/website/nodes.json -b /data/meshmap.net/configs/blocklist.txt"
     environment:
       MQTT_BROKER: ${MQTT_BROKER:-tcp://mqtt.meshtastic.org:1883}
       MQTT_USERNAME: ${MQTT_USERNAME:-meshdev}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile.meshobserv
     volumes:
-      - website_data:/data/meshmap.net/website
+      - ./website:/data/meshmap.net/website
       - ./configs/blocklist.txt:/data/meshmap.net/blocklist.txt:ro
     command:
       - "-f"
@@ -18,14 +18,10 @@ services:
     restart: unless-stopped
 
   nginx:
-    build:
-      context: .
-      dockerfile: Dockerfile.nginx
+    image: nginx:alpine
     volumes:
-      - website_data:/data/meshmap.net/website
+      - ./website:/data/meshmap.net/website:ro
+      - ./configs/nginx-http.conf:/etc/nginx/conf.d/default.conf:ro
     ports:
       - "${HTTP_PORT:-10081}:80"
     restart: unless-stopped
-
-volumes:
-  website_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,15 @@ services:
     restart: unless-stopped
 
   nginx:
-    image: nginx:alpine
+    build:
+      context: .
+      dockerfile: Dockerfile.nginx
     volumes:
-      - ./website:/data/meshmap.net/website:ro
+      - ./website:/data/meshmap.net/website
       - ./configs/nginx-http.conf:/etc/nginx/conf.d/default.conf:ro
+    environment:
+      SITE_TITLE: ${SITE_TITLE:-MeshMap}
+      SITE_URL: ${SITE_URL:-https://meshmap.net/}
     ports:
       - "${HTTP_PORT:-10081}:80"
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     volumes:
       - website_data:/data/meshmap.net/website
     ports:
-      - "80:80"
+      - "${HTTP_PORT:-10081}:80"
     restart: unless-stopped
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  meshobserv:
+    build:
+      context: .
+      dockerfile: Dockerfile.meshobserv
+    volumes:
+      - website_data:/data/meshmap.net/website
+      - ./configs/blocklist.txt:/data/meshmap.net/blocklist.txt:ro
+    command:
+      - "-f"
+      - "/data/meshmap.net/website/nodes.json"
+      - "-b"
+      - "/data/meshmap.net/blocklist.txt"
+    environment:
+      MQTT_BROKER: ${MQTT_BROKER:-tcp://mqtt.meshtastic.org:1883}
+      MQTT_USERNAME: ${MQTT_USERNAME:-meshdev}
+      MQTT_PASSWORD: ${MQTT_PASSWORD:-large4cats}
+    restart: unless-stopped
+
+  nginx:
+    build:
+      context: .
+      dockerfile: Dockerfile.nginx
+    volumes:
+      - website_data:/data/meshmap.net/website
+    ports:
+      - "80:80"
+    restart: unless-stopped
+
+volumes:
+  website_data:

--- a/internal/meshtastic/mqtt.go
+++ b/internal/meshtastic/mqtt.go
@@ -43,10 +43,22 @@ func (c *MQTTClient) Connect() error {
 	randomId := make([]byte, 4)
 	rand.Read(randomId)
 	opts := mqtt.NewClientOptions()
-	opts.AddBroker("tcp://mqtt.meshtastic.org:1883")
+	broker := os.Getenv("MQTT_BROKER")
+	if broker == "" {
+		broker = "tcp://mqtt.meshtastic.org:1883"
+	}
+	username := os.Getenv("MQTT_USERNAME")
+	if username == "" {
+		username = "meshdev"
+	}
+	password := os.Getenv("MQTT_PASSWORD")
+	if password == "" {
+		password = "large4cats"
+	}
+	opts.AddBroker(broker)
 	opts.SetClientID(fmt.Sprintf("meshobserv-%x", randomId))
-	opts.SetUsername("meshdev")
-	opts.SetPassword("large4cats")
+	opts.SetUsername(username)
+	opts.SetPassword(password)
 	opts.SetOrderMatters(false)
 	opts.SetDefaultPublishHandler(c.handleMessage)
 	c.Client = mqtt.NewClient(opts)

--- a/scripts/init-nginx.sh
+++ b/scripts/init-nginx.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+envsubst '${SITE_TITLE} ${SITE_URL}' \
+  < /data/meshmap.net/website/index.html.template \
+  > /data/meshmap.net/website/index.html

--- a/scripts/init-website.sh
+++ b/scripts/init-website.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+mkdir -p /data/meshmap.net/website
+cp -rn /website-static/. /data/meshmap.net/website/

--- a/website/index.html.template
+++ b/website/index.html.template
@@ -1,0 +1,467 @@
+<!DOCTYPE html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+<meta name="theme-color" content="#fff">
+<meta name="description" content="A nearly live map of Meshtastic nodes seen by the official Meshtastic MQTT server">
+<title>${SITE_TITLE}</title>
+<link rel="preload" href="/nodes.json" as="fetch" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900">
+<link rel="stylesheet" href="https://unpkg.com/font-awesome@4.7.0/css/font-awesome.min.css">
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
+<link rel="stylesheet" href="https://unpkg.com/leaflet-easybutton@2.4.0/src/easy-button.css">
+<link rel="stylesheet" href="https://unpkg.com/leaflet-search@4.0.0/dist/leaflet-search.min.css">
+<link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css">
+<link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.Default.css">
+<link rel="manifest" href="/site.webmanifest">
+<style>
+  html, body {
+    height: 100%;
+  }
+  body {
+    margin: 0;
+    padding: 0;
+  }
+  body.dark {
+    filter: invert(1) hue-rotate(180deg) brightness(1.33);
+  }
+  body.dark .dark-hidden {
+    display: none;
+  }
+  body:not(.dark) .dark-only {
+    display: none;
+  }
+  #header {
+    background-color: #fff;
+    box-shadow: 0 0 4px 0 rgb(0 0 0 / 40%);
+    color: #333;
+    display: flex;
+    align-items: center;
+    gap: 1em;
+    font-family: "Inter", sans-serif;
+    font-size: 16px;
+    line-height: 1.2;
+    height: 40px;
+    padding: 0 17px 0 15px;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+  }
+  #header a {
+    color: inherit;
+    text-decoration: none;
+  }
+  #header a:hover {
+    opacity: 0.7;
+  }
+  #header a img {
+    display: block;
+  }
+  #header div:nth-child(2) {
+    flex-grow: 1;
+    text-align: right;
+  }
+  #map {
+    position: absolute;
+    top: 40px;
+    bottom: 0;
+    left: 0;
+    right: 0;
+  }
+  table {
+    border-collapse: collapse;
+  }
+  table :is(th, td) {
+    text-align: left;
+    vertical-align: top;
+  }
+  table :is(th, td):nth-child(n+2) {
+    padding-left: 1em;
+  }
+  .break {
+    word-break: break-all;
+  }
+  .leaflet-tooltip, .leaflet-popup-content {
+    font-family: "Inter", sans-serif;
+    font-size: 12px;
+  }
+  .leaflet-popup-content .title {
+    font-size: 13px;
+    font-weight: bold;
+    margin-bottom: 3px;
+  }
+  .leaflet-popup-content table {
+    margin-top: 1em;
+  }
+  .leaflet-right .leaflet-control-attribution {
+    text-align: right;
+  }
+  body.dark .leaflet-shadow-pane {
+    display: none;
+  }
+  body.dark :is(.leaflet-tooltip, .leaflet-popup-content-wrapper, .leaflet-popup-tip) {
+    box-shadow: 0 0 4px 0 rgb(0 0 0 / 40%);
+  }
+  @media (hover: none) {
+    .leaflet-tooltip-pane {
+      display: none;
+    }
+  }
+</style>
+<script>
+  const toggleDark = () => {
+    if (document.body.classList.toggle('dark')) {
+      document.querySelector('meta[name="theme-color"]').content = '#000'
+      window.localStorage.setItem('theme', 'dark')
+      return true
+    }
+    document.querySelector('meta[name="theme-color"]').content = '#fff'
+    window.localStorage.removeItem('theme')
+    return false
+  }
+  if (window.localStorage.getItem('theme') === 'dark') {
+    document.addEventListener('DOMContentLoaded', () => toggleDark())
+  }
+</script>
+<div id="header">
+  <div>
+    <a href="${SITE_URL}" title="${SITE_TITLE}">${SITE_TITLE}</a>
+  </div>
+  <div>
+    <a href="#" onclick="toggleDark();return false;" title="Toggle dark mode">
+      <i class="fa fa-moon-o fa-lg dark-hidden"></i>
+      <i class="fa fa-sun-o fa-lg dark-only"></i>
+    </a>
+  </div>
+  <div>
+    <a href="https://github.com/brianshea2/meshmap.net?tab=readme-ov-file#faqs" title="FAQs"><i class="fa fa-question-circle fa-lg"></i></a>
+  </div>
+  <div>
+    <a href="https://github.com/brianshea2/meshmap.net" title="GitHub"><i class="fa fa-github fa-lg"></i></a>
+  </div>
+  <div>
+    <a href="https://meshtastic.org/" title="Powered by Meshtastic">
+      <img alt="Meshtastic" src="/m-pwrd_bw_noborder-min.svg" style="width:1.2em;height:1.2em;">
+    </a>
+  </div>
+</div>
+<div id="map"></div>
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+<script src="https://unpkg.com/leaflet-easybutton@2.4.0/src/easy-button.js"></script>
+<script src="https://unpkg.com/leaflet-search@4.0.0/dist/leaflet-search.min.js"></script>
+<script src="https://unpkg.com/leaflet.markercluster@1.5.3/dist/leaflet.markercluster.js"></script>
+<script>
+  let lastActiveNode
+  let markersByNode = {}
+  let nodesBySearchString = {}
+  const ipinfoToken = 'aeb066758afd49'
+  const updateInterval = 65000
+  // encodes html reserved characters and ascii control characters
+  const html = str => str
+    ?.replace(/[\x00-\x1F]/g, c => `\\x${c.charCodeAt(0).toString(16).toUpperCase().padStart(2, '0')}`)
+    .replace(/["&<>]/g, c => `&#${c.charCodeAt(0)};`)
+  // makes more human-readable time duration strings
+  const duration = d => {
+    let s = ''
+    if (d > 86400) {
+      s += `${Math.floor(d / 86400)}d `
+      d %= 86400
+    }
+    if (d > 3600) {
+      s += `${Math.floor(d / 3600)}h `
+      d %= 3600
+    }
+    s += `${Math.floor(d / 60)}min`
+    return s
+  }
+  const since = t => `${duration(Date.now() / 1000 - t)} ago`
+  // init map
+  const map = L.map('map', {
+    center: window.localStorage.getItem('center')?.split(',') ?? [25, 0],
+    zoom: window.localStorage.getItem('zoom') ?? 2,
+    attributionControl: false,
+    zoomControl: false,
+    worldCopyJump: true,
+  })
+  // add tiles
+  L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: 'Map tiles from <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    maxZoom: 17,
+  }).addTo(map)
+  // add marker group
+  const markers = L.markerClusterGroup({
+    maxClusterRadius: zoom => zoom < 3 ? 40 : 30,
+  }).addTo(map)
+  // add node details layer (precision rectangle, relation lines)
+  const detailsLayer = L.layerGroup().addTo(map)
+  map.on('click', () => detailsLayer.clearLayers())
+  // add search control
+  map.addControl(new L.Control.Search({
+    layer: markers,
+    propertyName: 'searchString',
+    initial: false,
+    position: 'topleft',
+    marker: false,
+    moveToLocation: (_, s) => showNode(nodesBySearchString[s]),
+  }))
+  // add zoom control
+  L.control.zoom({position: 'topright'}).addTo(map)
+  // add geolocation control
+  L.easyButton({
+    position: 'topright',
+    states: [
+      {
+        stateName: 'geolocation-button',
+        title: 'Center map to current IP geolocation',
+        icon: 'fa-crosshairs fa-lg',
+        onClick: () => {
+          fetch(`https://ipinfo.io/json?token=${ipinfoToken}`)
+            .then(r => r.json())
+            .then(({loc}) => loc && map.flyTo(loc.split(','), 10))
+            .catch(e => console.error('Failed to set location:', e))
+        },
+      },
+    ],
+  }).addTo(map)
+  // add attribution control
+  const attribution = L.control.attribution({position: 'bottomright', prefix: false}).addTo(map)
+  // updates attribution with given count of nodes
+  const updateNodeCount = count => attribution.setPrefix(`
+    ${count.toLocaleString()} nodes from
+    <a href="https://meshtastic.org/docs/software/integrations/mqtt/#public-mqtt-server">Meshtastic MQTT</a>
+  `)
+  // track and store map position
+  map.on('moveend', () => {
+    const center = map.getCenter()
+    window.localStorage.setItem('center', [center.lat, center.lng].join(','))
+  })
+  map.on('zoomend', () => {
+    window.localStorage.setItem('zoom', map.getZoom())
+  })
+  // generates html for a node link
+  const nodeLink = (num, label) => `<a href="#${num}" onclick="showNode(${num});return false;">${html(label)}</a>`
+  // updates node map markers
+  const updateNodes = data => {
+    const popupWasOpen = lastActiveNode && markersByNode[lastActiveNode]?.isPopupOpen()
+    const detailsLayerWasPopulated = detailsLayer.getLayers().length > 0
+    markersByNode = {}
+    nodesBySearchString = {}
+    markers.clearLayers()
+    detailsLayer.clearLayers()
+    let reactivate = () => {}
+    const relationsByNode = {}
+    Object.entries(data).forEach(([nodeNum, node]) => {
+      const {
+        longName, shortName, hwModel, role,
+        fwVersion, region, modemPreset, hasDefaultCh, onlineLocalNodes,
+        latitude, longitude, altitude, precision,
+        batteryLevel, voltage, chUtil, airUtilTx, uptime,
+        temperature, relativeHumidity, barometricPressure, lux,
+        windDirection, windSpeed, windGust, radiation, rainfall1, rainfall24,
+        neighbors, seenBy
+      } = node
+      const id = `!${Number(nodeNum).toString(16)}`
+      const position = [latitude, longitude].map(x => x / 10000000)
+      let precisionCorners
+      if (precision && precision > 0 && precision < 32) {
+        const [latLo, latHi] = [latitude & (0xffffffff << (32 - precision)), latitude | (0xffffffff >>> precision)].sort((a, b) => a - b)
+        const [longLo, longHi] = [longitude & (0xffffffff << (32 - precision)), longitude | (0xffffffff >>> precision)].sort((a, b) => a - b)
+        precisionCorners = [
+          [latLo, longLo].map(x => x / 10000000),
+          [latHi, longHi].map(x => x / 10000000)
+        ]
+      }
+      const seenByNums = new Set(
+        Object.keys(seenBy)
+          .map(topic => topic.match(/\/!([0-9a-f]+)$/))
+          .filter(match => match)
+          .map(match => parseInt(match[1], 16))
+      )
+      relationsByNode[nodeNum] ??= {}
+      seenByNums.forEach(seenByNum => {
+        relationsByNode[seenByNum] ??= {}
+        const relationObj = relationsByNode[nodeNum][seenByNum] ?? relationsByNode[seenByNum][nodeNum] ?? {}
+        relationsByNode[nodeNum][seenByNum] = relationObj
+        relationsByNode[seenByNum][nodeNum] = relationObj
+        relationObj.mqtt = true
+      })
+      if (neighbors) {
+        Object.keys(neighbors).forEach(neighborNum => {
+          relationsByNode[neighborNum] ??= {}
+          const relationObj = relationsByNode[nodeNum][neighborNum] ?? relationsByNode[neighborNum][nodeNum] ?? {}
+          relationsByNode[nodeNum][neighborNum] = relationObj
+          relationsByNode[neighborNum][nodeNum] = relationObj
+          relationObj.neighbor = true
+        })
+      }
+      const drawNodeDetails = () => {
+        detailsLayer.clearLayers()
+        // precision rectangle
+        if (precisionCorners) {
+          L.rectangle(precisionCorners, {color: '#ffa932'}).addTo(detailsLayer)
+        }
+        // relation lines
+        Object.entries(relationsByNode[nodeNum]).forEach(([relatedNum, relationObj]) => {
+          if (data[relatedNum] === undefined) {
+            return
+          }
+          const relatedPosition = [data[relatedNum].latitude, data[relatedNum].longitude].map(x => x / 10000000)
+          const relationContent = `
+            <table><tbody>
+            <tr><th>Related node</th><td>${nodeLink(relatedNum, `!${Number(relatedNum).toString(16)}`)}</td></tr>
+            <tr><th>Relation type</th><td>${[relationObj.neighbor && 'Neighbor', relationObj.mqtt && 'MQTT uplink'].filter(v => v).join(', ')}</td></tr>
+            <tr><th>Distance</th><td>${Math.round(map.distance(position, relatedPosition)).toLocaleString()} m</td></tr>
+            ${neighbors?.[relatedNum]?.snr ? `<tr><th>SNR</th><td>${neighbors[relatedNum].snr} dB</td></tr>` : ''}
+            </tbody></table>
+          `
+          L.polyline([position, relatedPosition])
+            .bindTooltip(relationContent, {opacity: 0.95, sticky: true})
+            .on('click', () => showNode(relatedNum))
+            .addTo(detailsLayer)
+        })
+      }
+      const lastSeen = Math.max(...Object.values(seenBy))
+      const opacity = 1.0 - (Date.now() / 1000 - lastSeen) / 32400
+      const tooltipContent = `${html(longName)} (${html(shortName)}) ${since(lastSeen)}`
+      const popupContent = `
+        <div class="title">${html(longName)} (${html(shortName)})</div>
+        <div>${nodeLink(nodeNum, id)} | ${html(role)} | ${html(hwModel)}</div>
+        <table><tbody>
+        ${uptime             ? `<tr><th>Uptime</th><td>${duration(uptime)}</td></tr>`                                : ''}
+        ${batteryLevel       ? `<tr><th>Power</th><td>${batteryLevel > 100 ? 'Plugged in' : `${batteryLevel}%`}` +
+                               `${voltage ? ` (${voltage.toFixed(2)}V)` : ''}</td></tr>`                             : ''}
+        ${fwVersion          ? `<tr><th>Firmware</th><td>${html(fwVersion)}</td></tr>`                               : ''}
+        ${region             ? `<tr><th>LoRa config</th><td>${html(region)} / ${html(modemPreset)}</td></tr>`        : ''}
+        ${chUtil             ? `<tr><th>ChUtil</th><td>${chUtil.toFixed(2)}%</td></tr>`                              : ''}
+        ${airUtilTx          ? `<tr><th>AirUtilTX</th><td>${airUtilTx.toFixed(2)}%</td></tr>`                        : ''}
+        ${onlineLocalNodes   ? `<tr><th>Local nodes</th><td>${onlineLocalNodes}</td></tr>`                           : ''}
+        ${precisionCorners   ? `<tr><th>Map precision</th><td>` +
+                               `&#177;${Math.round(map.distance(...precisionCorners) / 2).toLocaleString()} m` +
+                               ` (orange rectangle)</td></tr>`                                                       : ''}
+        ${altitude           ? `<tr><th>Altitude</th><td>${altitude.toLocaleString()} m above MSL</td></tr>`         : ''}
+        ${temperature        ? `<tr><th>Temperature</th><td>${temperature.toFixed(1)}&#8451; / ` +
+                               `${(temperature * 1.8 + 32).toFixed(1)}&#8457;</td></tr>`                             : ''}
+        ${relativeHumidity   ? `<tr><th>Relative humidity</th><td>${Math.round(relativeHumidity)}%</td></tr>`        : ''}
+        ${barometricPressure ? `<tr><th>Barometric pressure</th><td>${Math.round(barometricPressure)} hPa</td></tr>` : ''}
+        ${windDirection || windSpeed ? `<tr><th>Wind</th><td>` +
+                                (windDirection ? `${windDirection}&#176;` : '') +
+                                (windDirection && windSpeed ? ' @ ' : '') +
+                                (windSpeed ? `${(windSpeed * 3.6).toFixed(1)}` : '') +
+                                (windSpeed && windGust ? ` G ${(windGust * 3.6).toFixed(1)}` : '') +
+                                (windSpeed ? ' km/h' : '') +
+                                `</td></tr>`                                                                         : ''}
+        ${lux                ? `<tr><th>Lux</th><td>${Math.round(lux)} lx</td></tr>`                                 : ''}
+        ${radiation          ? `<tr><th>Radiation</th><td>${radiation.toFixed(2)} µR/h</td></tr>`                    : ''}
+        ${rainfall1 || rainfall24 ? `<tr><th>Rainfall</th><td>` +
+                                (rainfall1 ? `${rainfall1.toFixed(2)} mm/h` : '') +
+                                (rainfall1 && rainfall24 ? ', ' : '') +
+                                (rainfall24 ? `${rainfall24.toFixed(2)} mm/24h` : '') +
+                                `</td></tr>`                                                                         : ''}
+        </tbody></table>
+        <table><thead>
+        <tr><th>Last seen</th><th>via</th><th>MQTT root</th><th>channel</th></tr>
+        </thead><tbody>
+        ${Array.from(
+          new Map(
+            Object.entries(seenBy)
+              .map(([topic, seen]) => (match => ({seen, via: match[3] ?? id, root: match[1], chan: match[2]}))(
+                topic.match(/^(.*)(?:\/2\/e\/(.*)\/(![0-9a-f]+)|\/2\/map\/)$/s)
+              ))
+              .sort((a, b) => a.seen - b.seen)
+              .map(v => [v.via, v])
+          ).values(),
+          ({seen, via, root, chan}) => `
+            <tr>
+            <td>${since(seen)}</td>
+            <td>${chan ? ((n, l) => data[n] ? nodeLink(n, l) : l)(parseInt(via.slice(1), 16), via === id ? 'self' : via) : 'MapReport'}</td>
+            <td class="break">${html(root)}</td>
+            <td class="break">${html(chan ?? 'n/a')}</td>
+            </tr>
+          `
+        ).reverse().join('')}
+        </tbody></table>
+      `
+      const searchString = `${longName} (${shortName}) ${id}`
+      nodesBySearchString[searchString] = nodeNum
+      markersByNode[nodeNum] = L.marker(position, {alt: 'Node', opacity, searchString})
+        .bindTooltip(tooltipContent, {opacity: 0.95})
+        .bindPopup(popupContent, {maxWidth: 600})
+        .on('popupopen', () => {
+          // set last active
+          lastActiveNode = nodeNum
+          // set URL fragment
+          history.replaceState(null, '', `#${nodeNum}`)
+          // draw precision rectangle, relation lines
+          drawNodeDetails()
+        })
+      if (nodeNum === lastActiveNode) {
+        if (popupWasOpen) {
+          reactivate = () => {
+            const cluster = markers.getVisibleParent(markersByNode[nodeNum])
+            if (typeof cluster?.spiderfy === 'function') {
+              cluster.spiderfy()
+            }
+            markersByNode[nodeNum].openPopup()
+          }
+        } else if (detailsLayerWasPopulated) {
+          reactivate = drawNodeDetails
+        }
+      }
+    })
+    markers.addLayers(Object.values(markersByNode))
+    reactivate()
+  }
+  // fetches node data, updates map, repeats
+  const drawMap = async () => {
+    try {
+      await fetch('/nodes.json').then(r => r.json()).then(updateNodes)
+      updateNodeCount(Object.keys(markersByNode).length)
+    } catch (e) {
+      console.error('Failed to update nodes:', e)
+    }
+    setTimeout(() => {
+      if (document.hidden) {
+        document.addEventListener('visibilitychange', drawMap, {once: true})
+      } else {
+        drawMap()
+      }
+    }, updateInterval)
+  }
+  // pans and zooms map to node and opens popup
+  const showNode = nodeNum => {
+    if (markersByNode[nodeNum] === undefined) {
+      return false
+    }
+    map.panTo(markersByNode[nodeNum].getLatLng())
+    setTimeout(() => {
+      markers.zoomToShowLayer(markersByNode[nodeNum], () => {
+        markersByNode[nodeNum].openPopup()
+      })
+    }, 300)
+    return true
+  }
+  // keep URL fragment in sync
+  window.addEventListener('hashchange', () => {
+    if (window.location.hash && !showNode(window.location.hash.slice(1))) {
+      history.replaceState(null, '', window.location.pathname)
+    }
+    if (!window.location.hash) {
+      map.closePopup()
+      detailsLayer.clearLayers()
+    }
+  })
+  map.on('popupclose', () => {
+    if (window.location.hash) {
+      history.replaceState(null, '', window.location.pathname)
+    }
+  })
+  // let's go!!!
+  attribution.setPrefix('Loading node data&hellip;')
+  drawMap().then(() => {
+    if (window.location.hash && !showNode(window.location.hash.slice(1))) {
+      history.replaceState(null, '', window.location.pathname)
+    }
+  })
+</script>


### PR DESCRIPTION
added docker compose setup with self-hosting improvements:

the dockerfiles handles the generation of the protobufs by itself, installing protobuf-compiler, libprotobuf-dev, and protoc-gen-go, cloning from the Meshtastic protobuf definitions -  and generating the Go code as part of the build stage. 
-> No manual pre-build step required any more.

Added feature for configurable mqtt broker. (if you host your own) - you can put this into .env - 
mqtt.go now reads MQTT_BROKER, MQTT_USERNAME, and MQTT_PASSWORD from the environment - fallback is public meshtstic defaults. 

added option for nginx port, so you can put this behind revese proxy if you need

added option to override site-title and url. so you can now put the site name there "mutzelmap - based on MeshMap"

.env.sample is also there.

changed nginx conf so that the hardcoded meshmap.net is now _ -> catch all - therefore you can handle servername upstream.

Thanks for your work!